### PR TITLE
Fix training control flow and game logic

### DIFF
--- a/cfr.py
+++ b/cfr.py
@@ -1,75 +1,76 @@
 import torch
 import numpy as np
-import ray  # Added import to fix NameError
+import ray
 from collections import defaultdict
-from game import terminal, simulate_action_batch, simulate_action  # Add simulate_action here
+
+from game import terminal, simulate_action
 from config import Config
 from datatypes import Action, Infoset
 
-# Local nodes as fallback
 nodes = defaultdict(lambda: {
     'regret_sum': torch.zeros(Config.NUM_ACTIONS, device=Config.DEVICE, dtype=Config.DTYPE),
     'strategy_sum': torch.zeros(Config.NUM_ACTIONS, device=Config.DEVICE, dtype=Config.DTYPE)
 })
+
 
 def get_strategy(regret_sum):
     regret_sum = torch.clamp(regret_sum, min=0)
     norm = regret_sum.sum()
     return regret_sum / norm if norm > 0 else torch.full((Config.NUM_ACTIONS,), 1.0 / Config.NUM_ACTIONS, device=Config.DEVICE, dtype=Config.DTYPE)
 
+
 def mccfr(infoset: Infoset, iteration, prob=1.0, actor=None, depth=0, max_depth=3, player=0):
     if terminal(infoset) or depth >= max_depth:
-        return simulate_action(infoset, None) + np.random.normal(0, 0.1)
-    
+        actions = [Action(i) for i in range(Config.NUM_ACTIONS)]
+        with torch.no_grad():
+            samples = [simulate_action(infoset, a) for a in actions]
+        return float(np.mean(samples))
+
     key = infoset.key
     if actor is not None:
         regret_sum = ray.get(actor.get_regret_sum.remote(key)).to(Config.DEVICE)
     else:
         regret_sum = nodes[key]['regret_sum']
-    
+
     strategy = get_strategy(regret_sum)
-    
+
     actions = [Action(i) for i in range(Config.NUM_ACTIONS)]
     sub_utils = torch.zeros(Config.NUM_ACTIONS, device=Config.DEVICE, dtype=Config.DTYPE)
     sampled_mask = torch.zeros(Config.NUM_ACTIONS, dtype=torch.bool, device=Config.DEVICE)
-    
-    # Sample and compute sub-utilities
+
     greedy_idx = torch.argmax(strategy)
     for a_idx in range(Config.NUM_ACTIONS):
         if np.random.rand() < Config.SAMPLING_RATE or a_idx == greedy_idx:
             next_infoset = Infoset(infoset.key[0], infoset.history + (actions[a_idx].value,))
-            next_player = 1 - player  # Alternate player
-            sub_util = mccfr(next_infoset, iteration, prob * strategy[a_idx], actor, depth+1, max_depth, next_player)
-            sub_utils[a_idx] = -sub_util if next_player == 0 else sub_util  # Negate if opponent's turn
+            next_player = 1 - player
+            sub_util = mccfr(next_infoset, iteration, prob * strategy[a_idx], actor, depth + 1, max_depth, next_player)
+            sub_utils[a_idx] = -sub_util if next_player == 0 else sub_util
             sampled_mask[a_idx] = True
-    
-    # Fill unsampled with mean of sampled (avoid bias/NaN)
+
     if sampled_mask.sum() > 0:
         sampled_mean = sub_utils[sampled_mask].mean()
         sub_utils[~sampled_mask] = sampled_mean
     else:
-        # Fallback if no samples (rare): use uniform estimate
-        sub_utils.fill_(0.0)  # Or simulate quick rollout
-    
+        sub_utils.fill_(0.0)
+
     util = torch.sum(strategy * sub_utils).item()
     regrets = sub_utils - util
-    
-    # Linear discount for sustained updates
+
     discount = iteration / (iteration + 10.0) if iteration > 0 else 1.0
     regret_delta = regrets * prob * discount
-    
-    # CFR+ clamping: Floor negative regrets in accumulation
+
     if actor is not None:
         current_regret = ray.get(actor.get_regret_sum.remote(key)).to(Config.DEVICE)
-        new_regret = torch.maximum(current_regret - regret_delta * (1 if player == 0 else -1), torch.zeros_like(regret_delta))  # Adjust sign for player
+        new_regret = torch.maximum(current_regret - regret_delta * (1 if player == 0 else -1), torch.zeros_like(regret_delta))
         actor.update_regret_sum.remote(key, new_regret - current_regret)
         actor.update_strategy_sum.remote(key, strategy * prob)
     else:
         current_regret = nodes[key]['regret_sum']
         nodes[key]['regret_sum'] = torch.maximum(current_regret - regret_delta * (1 if player == 0 else -1), torch.zeros_like(regret_delta))
         nodes[key]['strategy_sum'] += strategy * prob
-    
+
     return util
+
 
 def average_strategy(infoset: Infoset, actor=None):
     key = infoset.key

--- a/config.py
+++ b/config.py
@@ -1,5 +1,6 @@
 import torch
 
+
 class Config:
     DEVICE = 'cuda' if torch.cuda.is_available() else 'cpu'
     DTYPE = torch.bfloat16
@@ -17,6 +18,6 @@ class Config:
     FOLD_EQUITY_MEAN = 0.4
     FOLD_EQUITY_STD = 0.3
     EQUITY_STD = 0.1
-    EQUITY_ROLLOUTS = 20 
+    EQUITY_ROLLOUTS = 40
     BLUFF_FACTOR = 0.3
-    FOLD_PENALTY = 0.5 
+    FOLD_PENALTY = 0.5

--- a/datatypes.py
+++ b/datatypes.py
@@ -1,19 +1,25 @@
 from enum import Enum
+import hashlib
+
 
 class Suit(Enum):
     HEARTS, DIAMONDS, CLUBS, SPADES = range(4)
+
 
 class Action(Enum):
     FOLD = 0
     CALL = 1
     RAISE = 2
 
+
 class Card:
     def __init__(self, value: int, suit: Suit):
-        self.value = value  # 2-14 (A=14)
+        self.value = value
         self.suit = suit
 
+
 class Infoset:
-    def __init__(self, bucket_id: int, history: tuple = ()):
-        self.key = (bucket_id, hash(history))  # Abstracted state
-        self.history = history  # Actions tuple for terminal check
+    def __init__(self, bucket_id: int, history: tuple = ()):    
+        h = hashlib.sha256(str(history).encode()).hexdigest()[:16]
+        self.key = (int(bucket_id), h)
+        self.history = history

--- a/game.py
+++ b/game.py
@@ -1,12 +1,15 @@
 import torch
-from datatypes import Action
-from config import Config
+import numpy as np
 import eval7
 import multiprocessing as mp
 
+from datatypes import Action
+from config import Config
+
+
 def evaluate_hand(cards_ids):
     ranks_str = '23456789TJQKA'
-    suits_str = 'shdc'  # eval7 suit order: s=0, h=1, d=2, c=3
+    suits_str = 'shdc'
     cards = []
     for card_id in cards_ids:
         rank_id = card_id // 4
@@ -15,12 +18,14 @@ def evaluate_hand(cards_ids):
         cards.append(eval7.Card(card_str))
     return eval7.evaluate(cards)
 
-def hand_rank_tensor(hands):  # hands: (batch, 7) tensor of card ints (int64)
+
+def hand_rank_tensor(hands):
     batch_size = hands.shape[0]
-    hands_list = hands.cpu().numpy().tolist()  # Move to CPU list for multiprocessing
-    with mp.Pool(processes=24) as pool:  # Use all 24 threads on 7900X
+    hands_list = hands.cpu().numpy().tolist()
+    with mp.Pool(processes=24) as pool:
         ranks = pool.map(evaluate_hand, hands_list)
     return torch.tensor(ranks, dtype=torch.int32, device=Config.DEVICE)
+
 
 def simulate_equity_batch(holes, boards, num_opponents=Config.NUM_OPPONENTS):
     num_hands = len(holes)
@@ -30,13 +35,11 @@ def simulate_equity_batch(holes, boards, num_opponents=Config.NUM_OPPONENTS):
         end = min(start + batch_size, num_hands)
         batch_holes = torch.tensor([[c.rank * 4 + c.suit for c in h] for h in holes[start:end]], dtype=torch.int64, device=Config.DEVICE)
         batch_boards = torch.tensor([[c.rank * 4 + c.suit for c in b] for b in boards[start:end]], dtype=torch.int64, device=Config.DEVICE)
-        # Deck: remove used cards
         full_deck = torch.arange(52, dtype=torch.int64, device=Config.DEVICE).unsqueeze(0).repeat(end-start, 1)
         used = torch.cat((batch_holes, batch_boards), dim=1)
         mask = torch.zeros((end-start, 52), device=Config.DEVICE).scatter_(1, used, 1).bool()
         remaining = full_deck[~mask].reshape(end-start, -1)
-        # Rollout loop for more accurate equity
-        num_rollouts = 100  # Tune based on time; ~10-20x slower but better accuracy
+        num_rollouts = Config.EQUITY_ROLLOUTS
         rollout_wins = torch.zeros((end-start, num_rollouts), device=Config.DEVICE)
         for r in range(num_rollouts):
             perm = torch.randperm(remaining.shape[1], device=Config.DEVICE).repeat(end-start, 1)
@@ -49,33 +52,40 @@ def simulate_equity_batch(holes, boards, num_opponents=Config.NUM_OPPONENTS):
             rollout_wins[:, r] = (my_ranks.unsqueeze(1) < opp_ranks).float().mean(dim=1)
         wins = rollout_wins.mean(dim=1)
         equities[start:end] = wins + torch.randn(end-start, device=Config.DEVICE) * Config.EQUITY_STD
-    return equities.to(torch.float32).cpu().numpy()  # Cast to float32 before .numpy()
+    return equities.to(torch.float32).cpu().numpy()
+
 
 def simulate_action_batch(infosets, actions):
     results = np.zeros(len(infosets))
     for i, (infoset, action) in enumerate(zip(infosets, actions)):
+        if action is None:
+            raise ValueError("simulate_action_batch requires an explicit Action")
         deck = eval7.Deck()
         deck.shuffle()
         hole = deck.deal(2)
         board = deck.deal(len(infoset.history) % 5)
         equity = simulate_equity_batch([hole], [board])[0]
-        pot = Config.POT_SIZE + np.random.uniform(0, 100)  # Wider pot variance
+        pot = Config.POT_SIZE + np.random.uniform(0, 100)
         call_amt = Config.CALL_AMOUNT + np.random.uniform(0, 20)
         fold_equity = np.random.normal(Config.FOLD_EQUITY_MEAN, Config.FOLD_EQUITY_STD)
         bluff = np.random.uniform(0, Config.BLUFF_FACTOR) if action == Action.RAISE else 0
-        equity += bluff - (1 - equity) * 0.2 if action == Action.FOLD else 0  # Penalty for fold low equity
         if action == Action.FOLD:
-            results[i] = -call_amt / pot * Config.FOLD_PENALTY  # Higher loss
+            equity -= (1 - equity) * 0.2
+            results[i] = -call_amt / pot * Config.FOLD_PENALTY
         elif action == Action.CALL:
             results[i] = equity * pot / (pot + call_amt) - call_amt / pot
-        else:
+        elif action == Action.RAISE:
             raise_amt = call_amt * (Config.RAISE_MULTIPLIER + np.random.uniform(0, 2))
             new_pot = pot + raise_amt * (1 - fold_equity)
             results[i] = equity * new_pot / (new_pot + raise_amt) - raise_amt / pot + fold_equity * pot / new_pot * bluff
+        else:
+            raise ValueError(f"Unknown action: {action}")
     return results
+
 
 def simulate_action(infoset, action: Action):
     return simulate_action_batch([infoset], [action])[0]
+
 
 def terminal(infoset):
     return len(infoset.history) >= 4

--- a/train.py
+++ b/train.py
@@ -4,13 +4,16 @@ actor = None
 import os
 import signal
 import sys
-import torch
-import numpy as np
-import ray
+import json
 import logging
-import psutil  # Optional: For CPU usage logging
-from collections import defaultdict  # Added to fix NameError in actor
+from collections import defaultdict
+
+import numpy as np
+import torch
+import ray
+import psutil
 from torch.utils.tensorboard import SummaryWriter
+
 from cfr import mccfr, average_strategy
 from abstractions import simulate_features, create_buckets
 from config import Config
@@ -21,9 +24,10 @@ ray.init(num_cpus=24, num_gpus=1 if torch.cuda.is_available() else 0)
 
 writer = SummaryWriter()
 
-# Setup logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s',
+logging.basicConfig(level=logging.INFO,
+                    format='%(asctime)s - %(levelname)s - %(message)s',
                     handlers=[logging.FileHandler('training.log'), logging.StreamHandler()])
+
 
 @ray.remote
 class NodesActor:
@@ -48,91 +52,76 @@ class NodesActor:
     def get_all_keys(self):
         return list(self.nodes.keys())
 
+
 @ray.remote
-def run_mccfr(infoset, iteration, player):
-    return mccfr(infoset, iteration, player=0)
+def run_mccfr(infoset, iteration, actor):
+    return mccfr(infoset, iteration, actor=actor)
 
-def sigterm_handler(signum, frame):
-    logging.error("SIGTERM received; saving partial strategies and exiting.")
-    # Fetch and save strategies as in train() end
-    strategies = {}
-    for infoset in infosets:
-        strategy_sum = ray.get(actor.get_strategy_sum.remote(infoset.key))
-        if strategy_sum.sum() > 0:
-            strategies[infoset.key] = average_strategy(infoset, actor=actor).cpu().tolist()
-    np.save('partial_strategies.npy', strategies)
-    sys.exit(1)
-
-signal.signal(signal.SIGTERM, sigterm_handler)
 
 def train():
+    global infosets, actor
+
     features = simulate_features()
     buckets, _ = create_buckets(features)
     unique_buckets = np.unique(buckets)
-    infosets = [Infoset(bid) for bid in unique_buckets]
+    infosets = [Infoset(int(bid)) for bid in unique_buckets]
     actor = NodesActor.remote()
-    global infosets, actor  # Make these available everywhere
 
     def local_sigterm_handler(signum, frame):
         logging.error("SIGTERM received; saving partial strategies and exiting.")
-        if actor is not None and infosets is not None:
-            strategies = {}
-            for inf in infosets:
-                strategy_sum = ray.get(actor.get_strategy_sum.remote(inf.key))
-                if strategy_sum.sum() > 0:
-                    strategies[inf.key] = average_strategy(inf, actor=actor).cpu().tolist()
-            np.save('partial_strategies.npy', strategies)
+        strategies = {}
+        for inf in infosets:
+            strategy_sum = ray.get(actor.get_strategy_sum.remote(inf.key))
+            if strategy_sum.sum() > 0:
+                strategies[inf.key] = average_strategy(inf, actor=actor).cpu().tolist()
+        np.save('partial_strategies.npy', strategies)
+        with open('partial_strategies.json', 'w') as f:
+            json.dump(strategies, f)
         sys.exit(1)
 
     signal.signal(signal.SIGTERM, local_sigterm_handler)
-    # Quick health check for actor
+
     try:
         ray.get(actor.get_all_keys.remote())
         logging.info("NodesActor initialized successfully.")
     except Exception as e:
         logging.error(f"Actor initialization failed: {e}")
         raise
+
     try:
-    for it in range(Config.ITERATIONS):
-        futures = [run_mccfr.remote(infoset, it, actor) for infoset in infosets]
-        utils = ray.get(futures)
-        total_util = np.mean(utils)
-        if it % 1000 == 0:
-            regret_sums = ray.get([actor.get_regret_sum.remote(infoset.key) for infoset in infosets])
-            regrets = [rs.mean().item() for rs in regret_sums]
-            avg_regret = np.mean(regrets) if regrets else 0.0
-            vram_gb = torch.cuda.memory_allocated() / 1e9
-            cpu_percent = psutil.cpu_percent() if 'psutil' in globals() else 'N/A'
-            writer.add_scalar('Util/Avg', total_util, it)
-            writer.add_scalar('Regret/Avg', avg_regret, it)
-            log_msg = f"Iter {it}: Util {total_util:.2f}, Regret {avg_regret:.4f} | VRAM: {vram_gb:.2f} GB | CPU: {cpu_percent}% | Ray Dashboard: http://127.0.0.1:8265"
-            logging.info(log_msg)
-            print(log_msg)
-            if avg_regret == 0 and it > 0:
-                all_keys = ray.get(actor.get_all_keys.remote())
-                if all_keys:
-                    sample_regret = ray.get(actor.get_regret_sum.remote(all_keys[0]))
-                    debug_msg = f"Debug: Sample regrets {sample_regret}"
-                    logging.debug(debug_msg)
-                    print(debug_msg)
-                else:
-                    logging.warning("Debug: No nodes updated yet")
-            torch.cuda.empty_cache()
+        for it in range(Config.ITERATIONS):
+            futures = [run_mccfr.remote(inf, it, actor) for inf in infosets]
+            utils = ray.get(futures)
+            total_util = float(np.mean(utils))
+            if it % 1000 == 0:
+                regret_sums = ray.get([actor.get_regret_sum.remote(inf.key) for inf in infosets])
+                regrets = [rs.mean().item() for rs in regret_sums]
+                avg_regret = float(np.mean(regrets)) if regrets else 0.0
+                vram_gb = torch.cuda.memory_allocated() / 1e9
+                cpu_percent = psutil.cpu_percent() if 'psutil' in globals() else 'N/A'
+                writer.add_scalar('Util/Avg', total_util, it)
+                writer.add_scalar('Regret/Avg', avg_regret, it)
+                logging.info(
+                    f"Iter {it}: Util {total_util:.2f}, Regret {avg_regret:.4f} | "
+                    f"VRAM: {vram_gb:.2f} GB | CPU: {cpu_percent}% | Ray Dashboard: http://127.0.0.1:8265"
+                )
+                torch.cuda.empty_cache()
     except KeyboardInterrupt:
-    local_sigterm_handler(None, None)  # Save if you press Ctrl+C
+        local_sigterm_handler(None, None)
     finally:
-    # Fetch strategies from actor
-    strategies = {}
-    for infoset in infosets:
-        strategy_sum = ray.get(actor.get_strategy_sum.remote(infoset.key))
-        if strategy_sum.sum() > 0:
-            strategies[infoset.key] = average_strategy(infoset, actor=actor).cpu().tolist()
-    np.save('strategies.npy', strategies)
-    logging.info("Training complete; strategies saved.")
-    print("Training complete; strategies saved.")
+        strategies = {}
+        for inf in infosets:
+            strategy_sum = ray.get(actor.get_strategy_sum.remote(inf.key))
+            if strategy_sum.sum() > 0:
+                strategies[inf.key] = average_strategy(inf, actor=actor).cpu().tolist()
+        np.save('strategies.npy', strategies)
+        with open('strategies.json', 'w') as f:
+            json.dump(strategies, f)
+        logging.info("Training complete; strategies saved.")
+        writer.close()
+        ray.shutdown()
+
 
 if __name__ == "__main__":
     torch.set_default_dtype(Config.DTYPE)
     train()
-    writer.close()
-    ray.shutdown()


### PR DESCRIPTION
## Summary
- fix MCCFR training loop with proper globals, Ray actor wiring, and strategy export
- correct game simulation to use config rollouts and explicit actions
- implement deterministic infoset keys and unbiased leaf evaluation

## Testing
- `python -c "import eval7; print('ok')"`
- `python -c "from game import simulate_action_batch; from datatypes import Infoset, Action; print(simulate_action_batch([Infoset(0)], [Action.CALL]))"` *(fails: ModuleNotFoundError: No module named 'torch')*
- `python train.py` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_689cad608a4c8329a1964648a375f0f7